### PR TITLE
Add workaround for urls containing unencoded space

### DIFF
--- a/lib/html/pipeline/absolute_source_filter.rb
+++ b/lib/html/pipeline/absolute_source_filter.rb
@@ -24,7 +24,7 @@ module HTML
           else
             base = image_subpage_url
           end
-          src = URI.join(base, src).to_s rescue nil
+          src = URI.join(base, src.gsub(' ', '%20')).to_s rescue nil
         end
         src
       end

--- a/test/html/pipeline/absolute_source_filter_test.rb
+++ b/test/html/pipeline/absolute_source_filter_test.rb
@@ -18,6 +18,12 @@ class HTML::Pipeline::AbsoluteSourceFilterTest < Minitest::Test
       AbsoluteSourceFilter.call(orig, @options).to_s
   end
 
+  def test_rewrites_root_urls_with_space
+    orig = %(<p><img src="/an img.png"></p>)
+    assert_equal "<p><img src=\"#{@image_base_url}/an%20img.png\"></p>",
+      AbsoluteSourceFilter.call(orig, @options).to_s
+  end
+
   def test_rewrites_root_urls
     orig = %(<p><img src="/img.png"></p>)
     assert_equal "<p><img src=\"#{@image_base_url}/img.png\"></p>",


### PR DESCRIPTION
I don't know if you guys care about this but [this half-broken feed](https://randomc.net/feed/) contains images which src aren't properly encoded (namely they contain space).

This would lessen my maintenance burden if get merged. Thanks 🙂

(as side note, the `start_with?` check should include the `:` of the schema (`data:`, `/https?:/`) in my opinion because otherwise relative url which starts with data (`data/images/1.jpg`) or http (`http/images/1.jpg`) won't be handled properly.